### PR TITLE
Provide access to frodo instance in 'user

### DIFF
--- a/frodo-core/src/frodo/web.clj
+++ b/frodo-core/src/frodo/web.clj
@@ -15,7 +15,7 @@
 
      The return value of this function is passed to the 'stop!' function
      when the web server shuts down.")
-  
+
   (stop! [_ system]
     "A function called when the web server stops, used to tear down any
      necessary system state.
@@ -106,5 +106,6 @@
     (intern 'user 'start-frodo! #(do (refresh-namespaces) (start-instance! !instance (load-config))))
     (intern 'user 'stop-frodo! #(stop-instance! !instance))
     (intern 'user 'reload-frodo! #(reload-instance! !instance (load-config)))
+    (intern 'user 'frodo-instance #(@!instance))
 
     (start-instance! !instance (load-config))))


### PR DESCRIPTION
Intern another function to the 'user namespace, 'frodo-instance, which
will deref the instance ref so that the user can poke around in and
call functions on the instance map

Fixes #6 
